### PR TITLE
Move ruleset out of src/

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "Validate ruleset"
         uses: "szepeviktor/phpcs-ruleset-validator@v0.1.0"
         with:
-            xml_ruleset: "src/Ramsey/ruleset.xml"
+            xml_ruleset: "Ramsey/ruleset.xml"
 
   functional-tests:
     name: "Standards Tests"

--- a/Ramsey/ruleset.xml
+++ b/Ramsey/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../vendor/squizlabs/php_codesniffer/phpcs.xsd" name="Ramsey">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd" name="Ramsey">
 
     <description>A common coding standard for Ramsey's PHP libraries.</description>
 

--- a/captainhook.json
+++ b/captainhook.json
@@ -47,7 +47,7 @@
                 "conditions": [
                     {
                         "exec": "\\CaptainHook\\App\\Hook\\Condition\\FileStaged\\Any",
-                        "args": [["src/Ramsey/ruleset.xml"]]
+                        "args": [["Ramsey/ruleset.xml"]]
                     }
                 ]
             }

--- a/resources/xmllint
+++ b/resources/xmllint
@@ -8,7 +8,7 @@
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 
-const RULESET = 'src/Ramsey/ruleset.xml';
+const RULESET = 'Ramsey/ruleset.xml';
 const XML_SCHEMA = 'resources/XMLSchema.xsd';
 const PHPCS_SCHEMA = 'vendor/squizlabs/php_codesniffer/phpcs.xsd';
 

--- a/resources/xmllint-fix
+++ b/resources/xmllint-fix
@@ -5,7 +5,7 @@
  * Format ruleset XML file.
  */
 
-const RULESET = 'src/Ramsey/ruleset.xml';
+const RULESET = 'Ramsey/ruleset.xml';
 
 // Change to the repository root.
 chdir(realpath(dirname(__FILE__, 2)));


### PR DESCRIPTION
## Description

Move ruleset to `/Ramsey`.

## Motivation and context

Every PHPCS ruleset I've seen/written uses one directory in the root.
That is all.

